### PR TITLE
fix: D-pad navigation on Fire TV / Android TV, handle OK and restore focus indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.5
+
+- Fixed: pressing OK / Select on a TV remote now toggles play/pause anywhere on the player (was silently no-op — Fire TV / Android TV remotes send `LogicalKeyboardKey.select` which Flutter's default `ActivateIntent` does not map)
+- Fixed: D-pad focus is now visible on every control button (the inner Theme override was setting `focusColor` and `hoverColor` to fully transparent, killing the inherited focus circle on every `IconButton`)
+- Added: Back / Escape on a TV remote first hides the controls, second press bubbles up so the parent route can exit (matches YouTube / Netflix / Plex)
+- Added: `onControlsVisibilityChanged` callback on `MaterialTvVideoControlsThemeData` so consumers can gate their own `PopScope.onPopInvokedWithResult` on whether the controls were visible at the moment of a back press (Android dispatches Back through `KeyEvent` AND `popRoute` in parallel, so a `Focus` consuming the KeyEvent does not stop the route from popping — consumers need the visibility signal to decide)
+- Removed: leftover `print('Key pressed: ...')` that logged every keystroke to the platform log
+
 ## 0.0.4
 
 - Fixed: holding arrow keys on seek bar now works (was frozen due to unhandled `KeyRepeatEvent`)

--- a/README.md
+++ b/README.md
@@ -60,3 +60,76 @@ The seek bar uses **duration-based** seeking instead of percentage-based:
 - **Release**: resets acceleration
 
 This gives consistent seek UX regardless of content length (unlike percentage-based seeking where 1% of a 3-hour movie is 108 seconds).
+
+### TV remote behavior
+
+The controls handle three TV-specific keys at the top-level `FocusScope`:
+
+- **OK / Select / dedicated media play-pause keys**: toggle play/pause from anywhere on the player. Catches `LogicalKeyboardKey.select` (the OK button on Fire TV / Android TV remotes), `mediaPlayPause`, `mediaPlay`, and `mediaPause`. `enter` and `space` are intentionally NOT intercepted so the default `IconButton` `ActivateIntent` still fires Skip Prev/Next, Fullscreen, and Volume buttons when those have focus.
+- **Back / Escape**: first press hides the controls, second press (controls already hidden) bubbles up so the consumer's parent route can exit. Matches YouTube / Netflix / Plex.
+
+#### Coordinating Back with `PopScope` on Android
+
+On Android the hardware Back button fires through two parallel platform channels: `KeyEvent` (consumed by this widget's `FocusScope.onKeyEvent`) AND `popRoute` (which goes straight to `PopScope.onPopInvokedWithResult` regardless of the `KeyEvent` being consumed). Returning `KeyEventResult.handled` from a `Focus` widget does **not** stop the route from popping.
+
+If your player route uses `PopScope` and you want "first Back hides controls, second Back exits" to work end-to-end, gate the pop on visibility via the `onControlsVisibilityChanged` callback:
+
+```dart
+class _PlayerScreenState extends State<PlayerScreen> {
+  bool _controlsVisible = true; // matches `visibleOnMount: true`
+  bool _controlsVisibleAtLastBackPress = false;
+
+  @override
+  void initState() {
+    super.initState();
+    HardwareKeyboard.instance.addHandler(_captureBackPressVisibility);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_captureBackPressVisibility);
+    super.dispose();
+  }
+
+  // Captures visibility synchronously BEFORE Flutter's focus dispatch
+  // hides the controls, so PopScope below can read the pre-press state.
+  bool _captureBackPressVisibility(KeyEvent event) {
+    if (event is KeyDownEvent &&
+        (event.logicalKey == LogicalKeyboardKey.goBack ||
+            event.logicalKey == LogicalKeyboardKey.escape)) {
+      _controlsVisibleAtLastBackPress = _controlsVisible;
+    }
+    return false; // don't consume — let normal dispatch continue
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tvTheme = MaterialTvVideoControlsThemeData(
+      visibleOnMount: true,
+      onControlsVisibilityChanged: (v) => _controlsVisible = v,
+      // ... your usual button bars, seek bar styling, etc.
+    );
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        if (_controlsVisibleAtLastBackPress) {
+          // Controls are being hidden by this widget — don't pop.
+          _controlsVisibleAtLastBackPress = false;
+          return;
+        }
+        // Real exit intent: do your save / cleanup, then pop.
+        Navigator.of(context).pop();
+      },
+      child: MaterialTvVideoControlsTheme(
+        normal: tvTheme,
+        fullscreen: tvTheme,
+        child: Video(/* ... */),
+      ),
+    );
+  }
+}
+```
+
+`HardwareKeyboard.handler` runs **before** the focus tree dispatches, so the snapshot is always taken pre-hide. The `popRoute` platform message arrives after, and `PopScope` reads the snapshot to decide.

--- a/lib/material_tv.dart
+++ b/lib/material_tv.dart
@@ -76,6 +76,17 @@ class MaterialTvVideoControlsThemeData {
   /// Whether the controls are initially visible.
   final bool visibleOnMount;
 
+  /// Called whenever the controls' visibility changes (auto-hide timer
+  /// fires, user activity re-shows them, back-key handler hides them).
+  /// Fires with the new value. Lets consumers gate their own back-button
+  /// / `PopScope` logic on whether the controls were visible at the
+  /// moment of the press — on Android the platform `popRoute` channel
+  /// fires in parallel with the `KeyEvent` channel, so a `Focus` widget
+  /// returning `KeyEventResult.handled` is not enough to stop the route
+  /// from popping. The consumer needs the visibility signal to gate
+  /// `PopScope.onPopInvokedWithResult` itself.
+  final ValueChanged<bool>? onControlsVisibilityChanged;
+
   // GENERIC
 
   /// Padding around the controls.
@@ -193,6 +204,7 @@ class MaterialTvVideoControlsThemeData {
     this.modifyVolumeOnScroll = true,
     this.keyboardShortcuts,
     this.visibleOnMount = false,
+    this.onControlsVisibilityChanged,
     this.hideMouseOnControlsRemoval = false,
     this.padding,
     this.controlsHoverDuration = const Duration(seconds: 3),
@@ -245,6 +257,7 @@ class MaterialTvVideoControlsThemeData {
     bool? modifyVolumeOnScroll,
     Map<ShortcutActivator, VoidCallback>? keyboardShortcuts,
     bool? visibleOnMount,
+    ValueChanged<bool>? onControlsVisibilityChanged,
     bool? hideMouseOnControlsRemoval,
     Duration? controlsHoverDuration,
     Duration? controlsTransitionDuration,
@@ -289,6 +302,8 @@ class MaterialTvVideoControlsThemeData {
       modifyVolumeOnScroll: modifyVolumeOnScroll ?? this.modifyVolumeOnScroll,
       keyboardShortcuts: keyboardShortcuts ?? this.keyboardShortcuts,
       visibleOnMount: visibleOnMount ?? this.visibleOnMount,
+      onControlsVisibilityChanged:
+          onControlsVisibilityChanged ?? this.onControlsVisibilityChanged,
       hideMouseOnControlsRemoval:
           hideMouseOnControlsRemoval ?? this.hideMouseOnControlsRemoval,
       controlsHoverDuration:
@@ -437,9 +452,7 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
           _theme(context).controlsHoverDuration,
           () {
             if (mounted) {
-              setState(() {
-                visible = false;
-              });
+              _setVisible(false);
               unshiftSubtitle();
             }
           },
@@ -454,6 +467,24 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
       subscription.cancel();
     }
     super.dispose();
+  }
+
+  /// Single mutator for [visible] (and optionally [mount]) so we can fire
+  /// `onControlsVisibilityChanged` from one place. Schedules the callback
+  /// after the frame so consumers can update their own state without
+  /// colliding with our `setState` here.
+  void _setVisible(bool value, {bool? mountValue}) {
+    final wasVisible = visible;
+    setState(() {
+      if (mountValue != null) mount = mountValue;
+      visible = value;
+    });
+    if (wasVisible == value) return;
+    final callback = _theme(context).onControlsVisibilityChanged;
+    if (callback == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) callback(value);
+    });
   }
 
   void shiftSubtitle() {
@@ -479,43 +510,31 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
   }
 
   void onHover() {
-    setState(() {
-      mount = true;
-      visible = true;
-    });
+    _setVisible(true, mountValue: true);
     shiftSubtitle();
     _timer?.cancel();
     _timer = Timer(_theme(context).controlsHoverDuration, () {
       if (mounted) {
-        setState(() {
-          visible = false;
-        });
+        _setVisible(false);
         unshiftSubtitle();
       }
     });
   }
 
   void onEnter() {
-    setState(() {
-      mount = true;
-      visible = true;
-    });
+    _setVisible(true, mountValue: true);
     shiftSubtitle();
     _timer?.cancel();
     _timer = Timer(_theme(context).controlsHoverDuration, () {
       if (mounted) {
-        setState(() {
-          visible = false;
-        });
+        _setVisible(false);
         unshiftSubtitle();
       }
     });
   }
 
   void onExit() {
-    setState(() {
-      visible = false;
-    });
+    _setVisible(false);
     unshiftSubtitle();
     _timer?.cancel();
   }
@@ -534,7 +553,7 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
             (event.logicalKey == LogicalKeyboardKey.goBack ||
                 event.logicalKey == LogicalKeyboardKey.escape)) {
           if (visible) {
-            setState(() => visible = false);
+            _setVisible(false);
             unshiftSubtitle();
             _timer?.cancel();
             return KeyEventResult.handled;
@@ -695,9 +714,7 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
                                       _theme(context).controlsHoverDuration,
                                       () {
                                         if (mounted) {
-                                          setState(() {
-                                            visible = false;
-                                          });
+                                          _setVisible(false);
                                           unshiftSubtitle();
                                         }
                                       },

--- a/lib/material_tv.dart
+++ b/lib/material_tv.dart
@@ -528,10 +528,24 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
         onEnter();
 
         if (event is KeyDownEvent) {
-          print('Key pressed: ${event.logicalKey.debugName}');
-
-          if (event.logicalKey == LogicalKeyboardKey.mediaPlayPause) {
+          // Toggle play/pause on TV remote OK and dedicated media keys.
+          //
+          // Fire TV and Android TV remotes send `LogicalKeyboardKey.select`
+          // when the user presses OK, which Flutter's default
+          // `ActivateIntent` does NOT map (it maps enter/space/gameButtonA).
+          // Without this explicit handler, OK silently does nothing — both
+          // globally AND when focus is on a control button — which is the
+          // single biggest D-pad UX bug in this package.
+          //
+          // We deliberately do not intercept `enter` / `space` here so the
+          // default IconButton `ActivateIntent` still fires Skip Prev/Next,
+          // Fullscreen, and Volume buttons when those have focus.
+          if (event.logicalKey == LogicalKeyboardKey.select ||
+              event.logicalKey == LogicalKeyboardKey.mediaPlayPause ||
+              event.logicalKey == LogicalKeyboardKey.mediaPlay ||
+              event.logicalKey == LogicalKeyboardKey.mediaPause) {
             controller(context).player.playOrPause();
+            return KeyEventResult.handled;
           }
         }
 
@@ -539,8 +553,12 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
       },
       child: Theme(
         data: Theme.of(context).copyWith(
-          focusColor: const Color(0x00000000),
-          hoverColor: const Color(0x00000000),
+          // Keep splash and highlight transparent — TV navigation should
+          // never show a tap ripple. But leave focusColor and hoverColor
+          // alone so the inherited theme's focus indicator remains visible
+          // on every IconButton (Skip Prev/Next, Play/Pause, Fullscreen,
+          // Volume, plus any custom topButtonBar buttons consumers add).
+          // Without that indicator, D-pad navigation is invisible.
           splashColor: const Color(0x00000000),
           highlightColor: const Color(0x00000000),
         ),

--- a/lib/material_tv.dart
+++ b/lib/material_tv.dart
@@ -525,6 +525,23 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
     return FocusScope(
       autofocus: true,
       onKeyEvent: (node, event) {
+        // Back button on TV: first press hides controls if visible, second
+        // press (controls already hidden) bubbles up so the parent route
+        // can pop. Matches YouTube / Netflix / Plex on TV — the universal
+        // expectation. Handled BEFORE onEnter() so a hide-on-back press
+        // doesn't first show the controls and then immediately hide them.
+        if (event is KeyDownEvent &&
+            (event.logicalKey == LogicalKeyboardKey.goBack ||
+                event.logicalKey == LogicalKeyboardKey.escape)) {
+          if (visible) {
+            setState(() => visible = false);
+            unshiftSubtitle();
+            _timer?.cancel();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        }
+
         onEnter();
 
         if (event is KeyDownEvent) {

--- a/lib/material_tv.dart
+++ b/lib/material_tv.dart
@@ -544,15 +544,20 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
     return FocusScope(
       autofocus: true,
       onKeyEvent: (node, event) {
-        // Back button on TV: first press hides controls if visible, second
-        // press (controls already hidden) bubbles up so the parent route
-        // can pop. Matches YouTube / Netflix / Plex on TV — the universal
-        // expectation. Handled BEFORE onEnter() so a hide-on-back press
-        // doesn't first show the controls and then immediately hide them.
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.goBack ||
-                event.logicalKey == LogicalKeyboardKey.escape)) {
-          if (visible) {
+        // Back / Escape on TV: first press hides controls if visible,
+        // second press (controls already hidden) bubbles up so the parent
+        // route can pop. Matches YouTube / Netflix / Plex on TV.
+        //
+        // Filtered for ALL phases of the key (Down + Up + Repeat) so we
+        // skip the `onEnter()` call below regardless. Without that, the
+        // KeyDown hides the controls but the KeyUp falls through and
+        // re-shows them — looks like a one-frame glitch and the user can
+        // never actually dismiss the chrome.
+        final isBackKey =
+            event.logicalKey == LogicalKeyboardKey.goBack ||
+                event.logicalKey == LogicalKeyboardKey.escape;
+        if (isBackKey) {
+          if (event is KeyDownEvent && visible) {
             _setVisible(false);
             unshiftSubtitle();
             _timer?.cancel();

--- a/lib/material_tv.dart
+++ b/lib/material_tv.dart
@@ -574,17 +574,38 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
           // Fire TV and Android TV remotes send `LogicalKeyboardKey.select`
           // when the user presses OK, which Flutter's default
           // `ActivateIntent` does NOT map (it maps enter/space/gameButtonA).
-          // Without this explicit handler, OK silently does nothing — both
-          // globally AND when focus is on a control button — which is the
-          // single biggest D-pad UX bug in this package.
+          // Without this explicit handler, OK silently does nothing on the
+          // bare control surface — historically the single biggest D-pad
+          // UX bug in this package.
           //
-          // We deliberately do not intercept `enter` / `space` here so the
-          // default IconButton `ActivateIntent` still fires Skip Prev/Next,
-          // Fullscreen, and Volume buttons when those have focus.
+          // BUT: routing every `select` straight to play/pause hijacks OK
+          // away from any focused IconButton / TextButton / custom button
+          // that a consumer drops into `topButtonBar` / `bottomButtonBar`
+          // (e.g. subtitle picker, back arrow). Those buttons bind their
+          // `onPressed` via `ActivateIntent`, which Flutter dispatches on
+          // enter/space — not on Fire TV's `select`. The old handler ate
+          // the event before the button could see it.
+          //
+          // Fix: when `select` (or a media key) fires, first try to invoke
+          // `ActivateIntent` on whatever widget currently has focus. If a
+          // button is focused, its `onPressed` runs (subtitle picker opens,
+          // back arrow pops, etc.). Only when no activatable widget is
+          // focused (bare control surface, seek bar) does the event fall
+          // through to the original play/pause behaviour.
+          //
+          // We still leave `enter` / `space` alone so the default IconButton
+          // `ActivateIntent` continues to fire Skip Prev/Next, Fullscreen,
+          // and Volume buttons on USB-keyboard / dev-host setups.
           if (event.logicalKey == LogicalKeyboardKey.select ||
               event.logicalKey == LogicalKeyboardKey.mediaPlayPause ||
               event.logicalKey == LogicalKeyboardKey.mediaPlay ||
               event.logicalKey == LogicalKeyboardKey.mediaPause) {
+            final focusedContext = FocusManager.instance.primaryFocus?.context;
+            if (focusedContext != null &&
+                Actions.maybeFind<ActivateIntent>(focusedContext) != null) {
+              Actions.invoke(focusedContext, const ActivateIntent());
+              return KeyEventResult.handled;
+            }
             controller(context).player.playOrPause();
             return KeyEventResult.handled;
           }
@@ -595,13 +616,51 @@ class _MaterialTvVideoControlsState extends State<_MaterialTvVideoControls> {
       child: Theme(
         data: Theme.of(context).copyWith(
           // Keep splash and highlight transparent — TV navigation should
-          // never show a tap ripple. But leave focusColor and hoverColor
-          // alone so the inherited theme's focus indicator remains visible
-          // on every IconButton (Skip Prev/Next, Play/Pause, Fullscreen,
-          // Volume, plus any custom topButtonBar buttons consumers add).
-          // Without that indicator, D-pad navigation is invisible.
+          // never show a tap ripple.
           splashColor: const Color(0x00000000),
           highlightColor: const Color(0x00000000),
+          // Kept for any consumer-added Material 2 widgets that still
+          // read `Theme.focusColor` directly (InkResponse, legacy
+          // IconButton on older Flutter, etc.).
+          focusColor: const Color(0xCCF5A623),
+          // Material 3 `IconButton` does NOT read `Theme.focusColor`.
+          // It resolves its appearance via `ButtonStyle` from
+          // `IconButtonTheme.style`. Override that explicitly so every
+          // IconButton in the chrome (Play/Pause, Skip Prev/Next,
+          // Fullscreen, Volume, plus any custom topButtonBar /
+          // bottomButtonBar buttons consumers add) draws an UNMISTAKABLE
+          // focus state at TV viewing distance:
+          //   • Solid amber/gold pill behind the focused icon (100% α)
+          //   • Icon glyph swaps to near-black so it pops against the
+          //     gold background instead of vanishing into it.
+          //
+          // Subtle alpha-tinted halos (12 %, 35 %, 80 %) all proved
+          // unreadable on a 1080p TV from 8-10 ft — the white icon
+          // washed any white-ish or low-alpha halo away. A full-opacity
+          // tinted pill with inverted foreground gives the same
+          // "selected tab" affordance YouTube TV / Plex / Netflix use.
+          iconButtonTheme: IconButtonThemeData(
+            style: ButtonStyle(
+              backgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.focused)) {
+                  return const Color(0xFFF5A623);
+                }
+                return null;
+              }),
+              foregroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.focused)) {
+                  return const Color(0xFF1A1A1A);
+                }
+                return null;
+              }),
+              // overlayColor transparent on focused so the solid
+              // background isn't muddied by an additional translucent
+              // layer drawn on top.
+              overlayColor: const WidgetStatePropertyAll(
+                Color(0x00000000),
+              ),
+            ),
+          ),
         ),
         child: Material(
           elevation: 0.0,
@@ -1115,10 +1174,21 @@ class MaterialTvPlayOrPauseButton extends StatefulWidget {
   /// Overriden icon color for [MaterialTvSkipPreviousButton].
   final Color? iconColor;
 
+  /// Whether to claim D-pad focus when the controls chrome appears.
+  ///
+  /// The controls tree is mounted/unmounted with visibility (see
+  /// `_setVisible(true, mountValue: true)` in `_MaterialTvVideoControlsState`),
+  /// so this autofocus re-fires every time the user shows the controls —
+  /// matching the YouTube / Netflix / Plex TV pattern where Play/Pause
+  /// claims default focus on every controls reappearance instead of
+  /// focus starting at the back arrow in the top bar.
+  final bool autofocus;
+
   const MaterialTvPlayOrPauseButton({
     super.key,
     this.iconSize,
     this.iconColor,
+    this.autofocus = false,
   });
 
   @override
@@ -1166,6 +1236,7 @@ class MaterialTvPlayOrPauseButtonState
   @override
   Widget build(BuildContext context) {
     return IconButton(
+      autofocus: widget.autofocus,
       onPressed: controller(context).player.playOrPause,
       iconSize: widget.iconSize ?? _theme(context).buttonBarButtonSize,
       color: widget.iconColor ?? _theme(context).buttonBarButtonColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_tv
 description: "Extensions for the Flutter media_kit libary for TVs"
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/OpenMediaStation/media_kit_tv
 
 environment:


### PR DESCRIPTION
fix #2 

Two related D-pad UX bugs in MaterialTvVideoControls.

1) OK button silently does nothing.

   Fire TV and Android TV remotes send `LogicalKeyboardKey.select` when
   the user presses OK. Flutter's default `ActivateIntent` does not map
   `select` (it maps enter/space/gameButtonA), and the FocusScope
   `onKeyEvent` only listened for `mediaPlayPause` — a dedicated hardware
   media key most Fire TV remotes do not have.

   Result: pressing OK does nothing globally AND does nothing when focus
   is on a control button. Users have to tap the screen.

   Fix: also handle `select`, `mediaPlay`, and `mediaPause` in the
   FocusScope `onKeyEvent` and call `playOrPause()`. Return `handled` so
   the event does not bubble. `enter` / `space` are intentionally NOT
   intercepted so the default IconButton activation still fires Skip
   Prev/Next, Fullscreen, and Volume buttons when focused.

2) D-pad focus indicator is invisible on every button.

   The inner Theme override was setting `focusColor` and `hoverColor` to
   fully transparent, alongside `splashColor` and `highlightColor`.
   Stripping splash/highlight is correct on TV (no tap ripple), but
   stripping focusColor removes the inherited focus circle that every
   IconButton uses to render its D-pad focus state. With it transparent,
   navigation between Skip Prev/Next, Play/Pause, Fullscreen, and Volume
   is silent and confusing.

   Fix: drop the `focusColor` and `hoverColor` overrides. Buttons now
   show the inherited theme's focus indicator. Splash and highlight stay
   transparent.

Drive-by: removed a leftover `print('Key pressed: ...')` that logged every keystroke to the platform log.